### PR TITLE
fix tray

### DIFF
--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1577,14 +1577,14 @@ class PearGUI extends ReadyResource {
       return this.restart(...args)
     })
 
-    electron.ipcMain.on('tray', async (evt, opts) => {
+    electron.ipcMain.on('tray', (evt, opts) => {
       const tray = new Tray({
         opts,
         state: this.state,
         onMenuClick: (data) => evt.reply('tray', data)
       })
       this.#tray = tray
-      await tray.ready()
+      tray.ready()
     })
 
     electron.ipcMain.handle('untray', async () => {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1479,7 +1479,7 @@ class PearGUI extends ReadyResource {
 
     electron.ipcMain.on('exit', (e, code) => { process.exit(code) })
 
-    electron.ipcMain.on('id', async (event) => {
+    electron.ipcMain.on('id', (event) => {
       return (event.returnValue = event.sender.id)
     })
 
@@ -1577,13 +1577,12 @@ class PearGUI extends ReadyResource {
       return this.restart(...args)
     })
 
-    electron.ipcMain.on('tray', async (evt, opts) => {
+    electron.ipcMain.on('tray', (evt, opts) => {
       const tray = new Tray({
         opts,
         state: this.state,
         onMenuClick: (data) => evt.reply('tray', data)
       })
-      await tray.ready()
       this.#tray = tray
     })
 
@@ -1649,7 +1648,7 @@ class PearGUI extends ReadyResource {
       stream.write(data)
     })
 
-    electron.ipcMain.on('found', async (evt, id) => {
+    electron.ipcMain.on('found', (evt, id) => {
       const stream = new streamx.Readable({ read () {} })
 
       const ctrl = this.getCtrl(id)
@@ -1999,6 +1998,8 @@ class Tray extends ReadyResource {
     this.opts = opts
     this.state = state
     this.onMenuClick = onMenuClick
+
+    this.ready()
   }
 
   _close () {

--- a/gui/gui.js
+++ b/gui/gui.js
@@ -1577,13 +1577,14 @@ class PearGUI extends ReadyResource {
       return this.restart(...args)
     })
 
-    electron.ipcMain.on('tray', (evt, opts) => {
+    electron.ipcMain.on('tray', async (evt, opts) => {
       const tray = new Tray({
         opts,
         state: this.state,
         onMenuClick: (data) => evt.reply('tray', data)
       })
       this.#tray = tray
+      await tray.ready()
     })
 
     electron.ipcMain.handle('untray', async () => {
@@ -1998,8 +1999,6 @@ class Tray extends ReadyResource {
     this.opts = opts
     this.state = state
     this.onMenuClick = onMenuClick
-
-    this.ready()
   }
 
   _close () {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "pear": {
     "assets": {
       "ui": {
-        "link": "pear://0.2752.goowesg5dga9j1ryx47rsk9o4zms4541me4zerxsnbu8u99duh4o",
+        "link": "pear://0.917.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
         "name": "Pear Runtime",
         "only": [
           "/boot.bundle",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "pear": {
     "assets": {
       "ui": {
-        "link": "pear://0.1042.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
+        "link": "pear://0.2752.goowesg5dga9j1ryx47rsk9o4zms4541me4zerxsnbu8u99duh4o",
         "name": "Pear Runtime",
         "only": [
           "/boot.bundle",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "pear": {
     "assets": {
       "ui": {
-        "link": "pear://0.920.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
+        "link": "pear://0.1042.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
         "name": "Pear Runtime",
         "only": [
           "/boot.bundle",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "pear": {
     "assets": {
       "ui": {
-        "link": "pear://0.917.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
+        "link": "pear://0.920.qan8woecfzi9au3phram1zhtedhqjobsqfh73sq4a8obn9gnt87o",
         "name": "Pear Runtime",
         "only": [
           "/boot.bundle",


### PR DESCRIPTION
# Context
- in pear-doctor, `Tray - multiple runs` is failing due to race condtion when calling tray api multiple times

# Reason
- when calling to tray api, it will try to untray the previous tray first, wait until it's done, then ask for a new tray
https://github.com/holepunchto/pear-electron/blob/e0ceadb2acbb7db628d33b9b25254ef7e9584158/api.js#L151-L159

- However, in the electron main process, `electron.ipcMain.on('tray'` is attached with an async handler, then `this.#tray` might be not defined yet, then calling to `electron.ipcMain.handle('untray'` will do nothing
https://github.com/holepunchto/pear-electron/blob/ec1287c8bf4f314d9d9c3596913ec8b18b0cde62/gui/gui.js#L1580-L1595

# Solution
- Replace all async handlers in electron.ipcMain.on with sync handlers instead
- With changes in this PR
  - `this.#tray` will be always defined when calling tray api
  - `untray` will always wait for the tray to be ready and close it