### PR TITLE
normalize pathname

### DIFF
--- a/pre.js
+++ b/pre.js
@@ -12,8 +12,8 @@ function srcs (html) {
 
 async function configure (options) {
   const { stage = {} } = options
-  const url = new URL(global.Pear.config.applink + '/');
-  const pathname = normalize(url.pathname);
+  const url = new URL(global.Pear.config.applink + '/')
+  const pathname = normalize(url.pathname)
   const drive = new Localdrive(pathname)
   const html = (await drive.get(options.gui?.main ?? 'index.html')).toString()
   const entrypoints = srcs(html)


### PR DESCRIPTION
in url object, pathname always has a leading slash (also on windows, eg: "/C:/....."). to fix this issue we normalize