### PR TITLE
fix: correct receiveFrom call signature in Parent constructor

### DIFF
--- a/api.js
+++ b/api.js
@@ -83,7 +83,7 @@ module.exports = (api) => {
         constructor (id) {
           super()
           this.id = id
-          ipc.receiveFrom(id, (...args) => {
+          ipc.receiveFrom((...args) => {
             this.emit('message', ...args)
           })
         }


### PR DESCRIPTION
## Summary

Fix `ui.app.parent` throwing `TypeError: The "listener" argument must be of type function` when accessed from within a `ui.View`.

## Problem

The `Parent` class constructor was passing two arguments to `receiveFrom()`:

```javascript
ipc.receiveFrom(id, (...args) => {
  this.emit('message', ...args)
})
```

But `receiveFrom()` only accepts one argument (the listener function), so `id` was being treated as the listener, causing:

```
TypeError: The "listener" argument must be of type function. Received undefined
    at checkListener (events:140:11)
    at Readable.once (events:634:3)
    at get parent (pear-electron/lib/index.js:163:24)
```

## Solution

Remove the erroneous `id` argument to align with how `GuiCtrl#rxtx()` correctly calls `receiveFrom()`:

```javascript
ipc.receiveFrom((...args) => {
  this.emit('message', ...args)
})
```

## Test plan

- [x] Verified `ui.app.parent` no longer throws when accessed from a `ui.View`
- [x] Parent-child messaging works correctly after the fix

Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)