### PR TITLE
add subset of electron dialog methods

### DIFF
--- a/api.js
+++ b/api.js
@@ -37,7 +37,11 @@ module.exports = (api) => {
           screen: () => ipc.askForMediaAccess({ id, media: 'screen' })
         },
         desktopSources: (options = {}) => ipc.desktopSources(options),
-        getPathForFile: (file) => ipc.getPathForFile(file)
+        getPathForFile: (file) => ipc.getPathForFile(file),
+        showOpenDialog: (...args) => ipc.showOpenDialog(...args),
+        showSaveDialog: (...args) => ipc.showSaveDialog(...args),
+        showMessageBox: (...args) => ipc.showMessageBox(...args),
+        showErrorBox: (...args) => ipc.showErrorBox(...args)
       }
 
       class Found extends streamx.Readable {

--- a/gui/ipc.js
+++ b/gui/ipc.js
@@ -55,6 +55,11 @@ module.exports = class IPC {
   badge (...args) { return electron.ipcRenderer.invoke('badge', ...args) }
   find (...args) { return electron.ipcRenderer.invoke('find', ...args) }
 
+  showOpenDialog (...args) { return electron.dialog.showOpenDialog(...args) }
+  showSaveDialog (...args) { return electron.dialog.showSaveDialog(...args) }
+  showMessageBox (...args) { return electron.dialog.showMessageBox(...args) }
+  showErrorBox (...args) { return electron.dialog.showErrorBox(...args) }
+
   getPathForFile (file) { return electron.webUtils.getPathForFile(file) }
 
   tray (opts, listener) {


### PR DESCRIPTION
This adds the following dialog methods to the ipc/api:

- `electron.dialog.showOpenDialog()`
- `electron.dialog.showSaveDialog()`
- `electron.dialog.showMessageBox()`
- `electron.dialog.showErrorBox()`

The main use case I have is showOpenDialog/showSaveDialog to avoid needing File System APIs and be able to easily do some localdrive->mirror-drive->hyperdrive stuff based on user input.

Otherwise it's File System API -> stream from ui to pear-end -> stream to somewhere -> ... 

Unless there's another option I'm missing!

I skipped the sync methods and `showCertificateTrustDialog` as they seem a lot less likely to be used but could add them.

I didn't get super far because I got confused about the build process. Followed the `npm pack` instructions but after install never saw the methods show up. I'm clearly doing something wrong 😅

Anyway, I can make changes, add docs, etc. if this is something you're looking to add.